### PR TITLE
Added a hook to change the aggregation query to be able to add a subsite filter

### DIFF
--- a/src/Filters/DateFilter.php
+++ b/src/Filters/DateFilter.php
@@ -70,6 +70,8 @@ class DateFilter extends Filter
             }
         }
 
+        $this->extend('updateAggregationQuery', $query);
+
         $aggRange = new \Elastica\Aggregation\Range('range');
         $aggRange->setField($this->FieldName);
 

--- a/src/Filters/RangeFilter.php
+++ b/src/Filters/RangeFilter.php
@@ -56,6 +56,8 @@ class RangeFilter extends Filter
             }
         }
 
+        $this->extend('updateAggregationQuery', $query);
+
         $min = new \Elastica\Aggregation\Min('min');
         $min->setField($this->FieldName);
 

--- a/src/Filters/TermsFilter.php
+++ b/src/Filters/TermsFilter.php
@@ -112,6 +112,8 @@ class TermsFilter extends Filter
             }
         }
 
+        $this->extend('updateAggregationQuery', $aggFilterQuery);
+
         $agg = new \Elastica\Aggregation\Terms('terms');
         $agg->setField($this->FieldName);
         $agg->setOrder('_term', 'asc');


### PR DESCRIPTION
For one of our projects we needed to add an extra filter in the filters because we have 2 sites in 1 index. Now it's possible to add extra filters in the aggregation query in the project where you use this.