### PR TITLE
Feature/wc 46 47

### DIFF
--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -38,6 +38,10 @@ class Filter extends DataObject
         'Sort' => 'Int'
     ];
 
+    private static $required_fields = [
+        'Name',
+    ];
+
     private static $has_one = [
         'Page' => SiteTree::class
     ];
@@ -77,6 +81,12 @@ class Filter extends DataObject
         ]);
         if ($filters->count() > 0) {
             $result->addError('Name already exists');
+        }
+
+        foreach (self::$required_fields as $requiredField) {
+            if (empty($this->{$requiredField})) {
+                $result->addError(sprintf('%s is required', $requiredField));
+            }
         }
 
         return $result;

--- a/src/Filters/MultiMatchFilter.php
+++ b/src/Filters/MultiMatchFilter.php
@@ -63,6 +63,15 @@ class MultiMatchFilter extends Filter
         return $fields;
     }
 
+    public function onBeforeWrite()
+    {
+        parent::onBeforeWrite();
+
+        if (empty($this->Placeholder)) {
+            $this->Placeholder = $this->Name;
+        }
+    }
+
     public function getElasticaQuery()
     {
         $query = null;

--- a/src/Filters/TermsFilter.php
+++ b/src/Filters/TermsFilter.php
@@ -45,6 +45,15 @@ class TermsFilter extends Filter
         return $fields;
     }
 
+    public function onBeforeWrite()
+    {
+        parent::onBeforeWrite();
+
+        if (empty($this->Placeholder)) {
+            $this->Placeholder = $this->Name;
+        }
+    }
+
     public function getElasticaQuery()
     {
         $value = $this->getFilterField()->Value();


### PR DESCRIPTION
- [x]  checkout a project that uses this module (Flexcraft)
- [x] remove the module map from project
- [x] update composer.lock part to ` "name": "thewebmen/silverstripe-elastica",
            "version": "v2.2.6",
            "source": {
                "type": "git",
                "url": "https://github.com/thewebmen/silverstripe-elastica.git",
                "reference": "**863d3fe8b3ce5bf2162546f1f654772ef57fe54c**"
            },
            "dist": {
                "type": "zip",
                "url": "https://api.github.com/repos/thewebmen/silverstripe-elastica/zipball/**863d3fe8b3ce5bf2162546f1f654772ef57fe54c**",
                "reference": "**863d3fe8b3ce5bf2162546f1f654772ef57fe54c**",
                "shasum": ""
            },`
- [x] start the project
- [x] go to the admin, RecruitNowVacancyPage, tab Elastica
- [x] add a filter (Multimatch of Terms) and try to save it wihtout filling the name
- [x] observe you get an error message saying `Name is required`
- [x] fill the name, leave placeholder empty and save
- [x] observe placeholder is filled with the value of the name