### PR TITLE
WS-1893 Force live links for indexing

### DIFF
--- a/src/Extensions/FilterIndexPageItemExtension.php
+++ b/src/Extensions/FilterIndexPageItemExtension.php
@@ -107,14 +107,14 @@ class FilterIndexPageItemExtension extends SiteTreeExtension implements IndexIte
         $data['Visible'] = $this->getPageVisibility($this->owner);
         $data['Title'] = $this->owner->Title;
         $data['Content'] = $this->owner->Content;
-        $data['Url'] = $this->owner->AbsoluteLink();
+        $data['Url'] = $this->owner->getAbsoluteLiveLink(false);
 
         if (!isset($data[ElasticaService::SUGGEST_FIELD_NAME])) {
             $data[ElasticaService::SUGGEST_FIELD_NAME] = $this->fillSugest(['Title','Content'],$data);
         }
 
     }
-    
+
     public static function getIndexName()
     {
         $name =  sprintf('content-%s-%s', Environment::getEnv('ELASTICSEARCH_INDEX'), self::INDEX_SUFFIX);

--- a/src/Extensions/GridElementIndexExtension.php
+++ b/src/Extensions/GridElementIndexExtension.php
@@ -66,7 +66,7 @@ class GridElementIndexExtension extends DataExtension implements IndexItemInterf
         }
 
         if ($data['Visible']) {
-            $data['Url'] = $page->AbsoluteLink();
+            $data['Url'] = $page->getAbsoluteLiveLink(false);
             $data['Title'] = $page->getTitle();
         }
 


### PR DESCRIPTION
URLs with ?stage=Stage were ending up in the index. Probably due to "onAfterPublish" hooks where the reading mode isn't set to live. Using this method we don't have to worry about that anymore, it will always use the live link.

The boolean passed is to prevent ?stage=Live from being added, see method signature:

```php
public function getAbsoluteLiveLink($includeStageEqualsLive = true)
```